### PR TITLE
Remove newlines at end of cells

### DIFF
--- a/herzog/__init__.py
+++ b/herzog/__init__.py
@@ -81,6 +81,9 @@ class ParserObject:
         return self.cell_type in self._translate
 
     def to_ipynb_cell(self):
+        while self.lines and not self.lines[-1]:
+            # Strip whitespace off end of cell
+            self.lines.pop()
         jupyter_cell = dict(cell_type=self._translate[self.cell_type],
                             metadata=dict(),
                             source=os.linesep.join(self.lines))

--- a/tests/test_herzog.py
+++ b/tests/test_herzog.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import os
 import sys
+import json
 import unittest
 import subprocess
 
@@ -14,6 +15,17 @@ class TestHerzog(unittest.TestCase):
     def test_evaluate(self):
         p = subprocess.run([f"{sys.executable}", "tests/fixtures/example.py"])
         p.check_returncode()
+
+    def test_parser(self):
+        with open("tests/fixtures/fibonacci.py") as fh:
+            p = herzog.Parser(fh)
+            cells = [obj.to_ipynb_cell() for obj in p.objects
+                     if obj.has_ipynb_representation]
+        with open("tests/fixtures/fibonacci.ipynb") as fh:
+            expected = json.loads(fh.read())
+
+        for cell, expected_cell in zip(cells, expected['cells']):
+            self.assertEqual(cell, expected_cell)
 
     def test_generate(self):
         with open("tests/fixtures/example.py") as fh:


### PR DESCRIPTION
This makes interactive notebooks a little nicer to use.

closes #2 