### PR TITLE
Change herzog quoting.

### DIFF
--- a/herzog/parser.py
+++ b/herzog/parser.py
@@ -14,9 +14,11 @@ JUPYTER_MAGIC_PFX = "#%"
 class HerzogCell:
     _translate = {CellType.python: "code", CellType.markdown: "markdown"}
 
-    def __init__(self, cell_type: CellType, lines: Iterable[str]):
+    def __init__(self, cell_type: CellType, lines: List[str]):
         self.cell_type = cell_type
         self.lines: List[str] = list()
+        if lines[-1] == "pass":
+            lines.pop()
         for line in lines:
             if CellType.python == self.cell_type:
                 if "pass" == line:
@@ -26,8 +28,8 @@ class HerzogCell:
                 else:
                     self.lines.append(line)
             elif CellType.markdown == self.cell_type:
-                if '"""' == line:
-                    pass
+                if line.startswith('#'):
+                    self.lines.append(line[1:].strip())
                 else:
                     self.lines.append(line)
 

--- a/tests/fixtures/example.py
+++ b/tests/fixtures/example.py
@@ -8,13 +8,12 @@ import herzog
 
 
 with herzog.Cell("markdown"):
-    """
-    # This is a header
-    doom and gloom
-
-    ## frank is a ganster
-    evidence
-    """
+    # # This is a header
+    # doom and gloom
+    #
+    # ## frank is a ganster
+    # evidence
+    pass
 
 # Anything placed outside of a Cell context manager will not
 # be included in a cell. This is a good place for dev notes that should


### PR DESCRIPTION
Resolves #25 and #26.

Currently a literal `"""` in markdown creates a problem and `'''` is not valid at all.

I believe using `#` should be able to be blindly robust to all cases, especially in the case of translating back and forth:

Literal markdown:
```
'''
# This is a header
doom and gloom

## frank is a ganster
evidence
'''
```

->

```
with herzog.Cell("markdown"):
    # '''
    # # This is a header
    # doom and gloom
    #
    # ## frank is a ganster
    # evidence
    # '''
    pass
```

->

```
'''
# This is a header
doom and gloom

## frank is a ganster
evidence
'''
```

This should handle all cases, I believe.  Continuing to handle based on `"""` could get tricky, and would necessitate parsing the AST.  I like this method and prefer it over that, as it's dead simple.

