### PR TITLE
Skip treating pass as a part of the markdown.

### DIFF
--- a/herzog/parser.py
+++ b/herzog/parser.py
@@ -26,7 +26,7 @@ class HerzogCell:
                 else:
                     self.lines.append(line)
             elif CellType.markdown == self.cell_type:
-                if '"""' == line:
+                if line in ('"""', "pass"):
                     pass
                 else:
                     self.lines.append(line)


### PR DESCRIPTION
We skip `pass` in python and we skip the unique `"""` markers in markdown.  We should also skip `pass` in markdown, because it can be added and if it is, it may be duplicated when translating back and forth multiple times with `herzog`.

This basically accounts for the edge case:

```
with herzog.Cell('python'):
    """
    something something
    """
    pass
```

This isn't a big deal, as the `pass` is unnecessary.  This is just anticipating future behavior on the part of users.
